### PR TITLE
feat: add startup banner with version and release link

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,14 @@ vendor/
 # Build artifacts
 dist/
 build/
+.svelte-kit/
 coverage/
+.eslintcache
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# Runtime data
+data/
 
 # Logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,19 @@
 # Dependencies
 node_modules/
 
+# VCS
+.jj/
+
+# AI tooling
+.claude/
+
 # Build outputs
 /.svelte-kit
 /build
 dist/
+
+# Runtime data
+/data/
 
 # Environment and secrets
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:22-slim AS builder
+FROM node:25-alpine AS builder
 
 WORKDIR /app
+
+# Build deps for native modules (better-sqlite3)
+RUN apk add --no-cache python3 make g++
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
@@ -11,7 +14,10 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 
-FROM node:22-slim AS runtime
+# Production deps only (with native modules compiled)
+RUN pnpm prune --prod
+
+FROM node:25-alpine AS runtime
 
 WORKDIR /app
 
@@ -21,6 +27,7 @@ ENV METRICS_PORT=9091
 
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
 
 EXPOSE 9797 9091
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A simple Docker log viewer. Streams logs from the Docker socket with basic filte
 
 <img width="1912" height="794" alt="image" src="https://github.com/user-attachments/assets/32adda50-4914-4e76-b9fd-ef471d363a32" />
 
-
 ## Quick Start
 
 ```bash

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,8 @@
+import { printBanner } from '$lib/server/banner';
+import { env } from '$env/dynamic/private';
+import { version } from '../package.json';
+
+const port = env.PORT || '9797';
+const metricsPort = env.METRICS_PORT || '9091';
+
+printBanner(version, port, metricsPort);

--- a/src/lib/server/banner.ts
+++ b/src/lib/server/banner.ts
@@ -1,0 +1,15 @@
+export const banner = `
+██╗      ██████╗  ██████╗  ██████╗  █████╗ ██████╗ ██████╗ 
+██║     ██╔═══██╗██╔════╝ ██╔════╝ ██╔══██╗██╔══██╗██╔══██╗
+██║     ██║   ██║██║  ███╗██║  ███╗███████║██████╔╝██████╔╝
+██║     ██║   ██║██║   ██║██║   ██║██╔══██║██╔══██╗██╔══██╗
+███████╗╚██████╔╝╚██████╔╝╚██████╔╝██║  ██║██║  ██║██║  ██║
+╚══════╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝
+`;
+
+export function printBanner(version: string, port: string, metricsPort: string): void {
+	console.log(banner);
+	console.log(`  v${version} | http://localhost:${port} | metrics :${metricsPort}`);
+	console.log(`  https://github.com/taslabs-net/loggarr/releases/tag/v${version}`);
+	console.log('');
+}


### PR DESCRIPTION
## Summary

- Add ASCII art banner on server startup
- Display version, ports, and GitHub release link
- Version pulled from package.json at build time

Closes #10 (partial - startup logging portion)