### PR TITLE
chore: add 5 minute timeout to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: Docker Build
     runs-on: self-hosted
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,7 @@ jobs:
   checks:
     name: Lint, Type, Test
     runs-on: self-hosted
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   close-stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Handle stale issues and PRs
         uses: actions/github-script@v8

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,7 @@ jobs:
   auto-merge:
     name: Auto-merge Dependabot
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ jobs:
   label:
     name: Auto-label PR
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -26,6 +26,7 @@ jobs:
         endsWith(github.event.comment.body, ' /opencode')
       )
     runs-on: self-hosted
+    timeout-minutes: 5
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: self-hosted
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Add 5 minute safety timeout to all workflow jobs to prevent stuck builds.

**Workflows updated:**
- `checks.yml` - lint/type/test
- `build.yml` - Docker build
- `release.yml` - Docker build + push
- `labeler.yml` - PR labeling
- `close-stale-prs.yml` - Stale issue cleanup
- `dependabot-auto-merge.yml` - Auto-merge deps
- `opencode.yml` - AI operations

(`ci.yml` excluded - it only calls other workflows)