### PR TITLE
fix: increase Docker build timeout and fix corepack issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Docker Build
     runs-on: self-hosted
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: self-hosted
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build tools layer - cached separately
 FROM node:25-alpine AS base
 RUN apk add --no-cache python3 make g++
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm
 
 # Dependencies layer - cached when lockfile unchanged
 FROM base AS deps


### PR DESCRIPTION
## Summary

Fixes release workflow failures:

1. **Increased timeout** - Docker multi-platform builds need more than 5 minutes
   - `build.yml`: 5 → 15 minutes
   - `release.yml`: 5 → 15 minutes

2. **Fixed corepack issue** - `corepack enable` fails under QEMU emulation for arm64
   - Replaced `corepack enable && corepack prepare pnpm@latest --activate` with `npm install -g pnpm`

This should fix the release workflow and allow new images to be pushed.