### PR TITLE
fix: skip scripts during pnpm prune to avoid husky error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY svelte.config.js vite.config.ts tsconfig.json ./
 COPY src ./src
 COPY static ./static
 RUN pnpm build
-RUN pnpm prune --prod
+RUN pnpm prune --prod --ignore-scripts
 
 # Runtime layer - minimal
 FROM node:25-slim AS runtime


### PR DESCRIPTION
pnpm prune --prod runs prepare script which calls husky (already pruned)