### PR TITLE
fix: add curl to runtime image for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pnpm prune --prod --ignore-scripts
 
 # Runtime layer - minimal
 FROM node:25-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       - METRICS_PORT=9091
       - LOG_BUFFER_SIZE=100
     healthcheck:
-      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:9797/health']
+      test: ['CMD', 'curl', '-sf', 'http://localhost:9797/api/health']
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Install curl in runtime image (node:25-slim doesn't have wget)
- Update compose.yaml healthcheck to use curl