### PR TITLE
ci: skip release builds for documentation-only changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/labeler.yml'
+      - '.github/dependabot.yml'
+      - 'compose.yaml'
+      - '.env.example'
+      - '.prettierrc'
+      - '.prettierignore'
+      - '.npmrc'
+      - '.husky/**'
+      - 'cliff.toml'
+      - 'eslint.config.js'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Add `paths-ignore` to release workflow to skip builds when only non-code files change.

### Ignored paths:
| Path | Reason |
|------|--------|
| `*.md` | Documentation |
| `docs/**` | Documentation |
| `LICENSE` | Legal, no code |
| `.gitignore` | Git config |
| `.github/*.md` | PR/issue templates |
| `.github/ISSUE_TEMPLATE/**` | Issue templates |
| `.github/labeler.yml` | PR labeling config |
| `.github/dependabot.yml` | Dependabot config |
| `compose.yaml` | Example deployment config |
| `.env.example` | Example env vars |
| `.prettierrc` | Code formatting (dev only) |
| `.prettierignore` | Prettier config |
| `.npmrc` | npm config (dev only) |
| `.husky/**` | Git hooks (dev only) |
| `cliff.toml` | Changelog config |
| `eslint.config.js` | Linting (dev only) |

Fixes #27