### PR TITLE
perf: parallelize streams, batch log updates, add version display

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Docker Build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,9 @@ name: Checks
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Lint, Type, Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Checks

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,8 @@ export default ts.config(
 		languageOptions: {
 			globals: {
 				...globals.browser,
-				...globals.node
+				...globals.node,
+				__APP_VERSION__: 'readonly'
 			}
 		}
 	},

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,9 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	// Build-time constants from vite.config.ts
+	const __APP_VERSION__: string;
 }
 
 export {};

--- a/src/lib/components/LogViewer.svelte
+++ b/src/lib/components/LogViewer.svelte
@@ -169,6 +169,7 @@
 		{#if paused}
 			<span class="paused-indicator">PAUSED</span>
 		{/if}
+		<span class="version">v{__APP_VERSION__}</span>
 	</div>
 </div>
 
@@ -429,5 +430,9 @@
 	.paused-indicator {
 		color: var(--color-warning);
 		font-weight: 600;
+	}
+
+	.version {
+		margin-left: auto;
 	}
 </style>

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -87,19 +87,32 @@ export async function* streamAllLogs(signal?: AbortSignal, containerIds?: string
 		containers = containers.filter((c) => containerIds.includes(c.Id) || containerIds.includes(c.Names[0]?.replace(/^\//, '') || ''));
 	}
 
-	const streams: { container: ContainerInfo; stream: NodeJS.ReadableStream }[] = [];
+	// Establish all log streams in parallel for faster startup
+	// Use Promise.allSettled to handle partial failures gracefully
+	const streamResults = await Promise.allSettled(
+		containers.map(async (containerInfo) => {
+			const container = docker.getContainer(containerInfo.Id);
+			const logStream = await container.logs({
+				follow: true,
+				stdout: true,
+				stderr: true,
+				timestamps: false,
+				tail: 5
+			});
+			return { container: containerInfo, stream: logStream };
+		})
+	);
 
-	for (const containerInfo of containers) {
-		const container = docker.getContainer(containerInfo.Id);
-		const logStream = await container.logs({
-			follow: true,
-			stdout: true,
-			stderr: true,
-			timestamps: false,
-			tail: 10
-		});
-		streams.push({ container: containerInfo, stream: logStream });
-	}
+	// Filter out failed streams and log errors
+	const streams = streamResults
+		.filter((result): result is PromiseFulfilledResult<{ container: ContainerInfo; stream: NodeJS.ReadableStream }> => {
+			if (result.status === 'rejected') {
+				console.error('Failed to connect to container log stream:', result.reason);
+				return false;
+			}
+			return true;
+		})
+		.map((result) => result.value);
 
 	const logQueue: LogEntry[] = [];
 	let resolveWait: (() => void) | null = null;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,6 +22,41 @@
 	let showSnapshotBrowser = $state(false);
 	let viewingSnapshot = $state<{ name: string; logs: LogEntry[] } | null>(null);
 
+	// Log batching - debounce updates to reduce re-renders (similar to Dozzle)
+	let pendingLogs: LogEntry[] = [];
+	let flushTimer: ReturnType<typeof setTimeout> | null = null;
+	let lastFlush = 0;
+	const DEBOUNCE_MS = 250; // debounce interval
+	const MAX_WAIT_MS = 1000; // force flush after this long
+
+	function flushLogs() {
+		if (pendingLogs.length === 0) return;
+
+		// Batch update: add all pending logs at once
+		logs = [...logs, ...pendingLogs].slice(-bufferSize);
+		pendingLogs = [];
+		flushTimer = null;
+		lastFlush = Date.now();
+	}
+
+	function queueLog(entry: LogEntry) {
+		pendingLogs.push(entry);
+
+		// Clear existing timer
+		if (flushTimer) {
+			clearTimeout(flushTimer);
+		}
+
+		// Force flush if we've waited too long (maxWait)
+		const timeSinceLastFlush = Date.now() - lastFlush;
+		if (timeSinceLastFlush >= MAX_WAIT_MS) {
+			flushLogs();
+		} else {
+			// Debounce: schedule flush
+			flushTimer = setTimeout(flushLogs, DEBOUNCE_MS);
+		}
+	}
+
 	async function fetchContainers() {
 		try {
 			const response = await fetch('/api/v1/containers');
@@ -51,7 +86,7 @@
 			const entry = JSON.parse(event.data) as LogEntry;
 			entry.timestamp = new Date(entry.timestamp);
 
-			logs = [...logs.slice(-(bufferSize - 1)), entry];
+			queueLog(entry);
 		};
 
 		eventSource.onerror = () => {
@@ -64,6 +99,14 @@
 		if (eventSource) {
 			eventSource.close();
 			eventSource = null;
+		}
+		// Clean up pending logs
+		if (flushTimer) {
+			clearTimeout(flushTimer);
+			flushTimer = null;
+		}
+		if (pendingLogs.length > 0) {
+			flushLogs(); // Flush any remaining logs
 		}
 		connected = false;
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version)
+	}
 });


### PR DESCRIPTION
## Problem
With many containers (17+), the UI freezes on initial load because:
1. Log streams are established **sequentially** - each container waits for the previous one
2. Every single log triggers a re-render

## Solution (inspired by Dozzle)

### Backend: Parallel stream setup
- Use `Promise.allSettled` to establish all log streams in parallel
- Gracefully handles partial failures (if one container fails, others still stream)
- Reduced `tail` from 10 to 5 to speed up initial load
- Logs errors for any container that fails to connect

### Frontend: Debounced log batching
- Buffer incoming logs instead of updating state on every message
- **250ms debounce** with **1000ms max wait** (same pattern as Dozzle)
- Batch flushes reduce re-renders from potentially 100+/sec to ~4/sec
- Clean up timers on disconnect to prevent memory leaks

### UI: Version display
- Show app version in lower-right corner of status bar
- Version injected at build time via Vite `define`

### Security: Workflow permissions
- Add explicit `permissions: contents: read` to ci.yml, checks.yml, build.yml
- Fixes CodeQL warning about missing workflow permissions

### Research
- Confirmed SSE is the right approach (Dozzle with 11k+ stars uses it)
- `Promise.allSettled` over `Promise.all` for fault tolerance
- Debounced batching is the standard pattern for high-frequency updates