### PR TITLE
feat: add log search, snapshot export, and keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ A simple Docker log viewer. Streams logs from the Docker socket with basic filte
 - **Stream logs** from all Docker containers via the Docker socket
 - **Pause/Resume** log streaming
 - **Save snapshots** of paused log state
+- **Export snapshots** to Markdown, JSON, or plain text
+- **Search logs** with regex support and real-time filtering
 - **Capture history** - configurable line buffer (default: 100, max: 1000)
 - **Filter by log level** - alert, error, warning, info, debug
+- **Keyboard shortcuts** for power users (press `?` for help)
 - **SQLite storage** for saved snapshots and configuration (streaming logs are memory-only)
 - **Prometheus metrics** on port 9091
 - **Health check** endpoint at `/health`
@@ -47,6 +50,19 @@ Then open `http://localhost:9797` in your browser.
 | `METRICS_PORT`       | `9091`  | Prometheus metrics port           |
 | `LOG_BUFFER_SIZE`    | `100`   | Number of lines to keep in memory |
 | `LOG_BUFFER_MAX`     | `1000`  | Maximum configurable buffer size  |
+
+## Keyboard Shortcuts
+
+| Key       | Action                      |
+| --------- | --------------------------- |
+| `Space`   | Pause / Resume              |
+| `/`       | Focus search                |
+| `j` / `k` | Scroll down / up            |
+| `g g`     | Go to top                   |
+| `G`       | Go to bottom                |
+| `s`       | Save snapshot (when paused) |
+| `?`       | Show shortcuts help         |
+| `Esc`     | Close help                  |
 
 ## Requirements
 

--- a/src/lib/components/LogViewer.svelte
+++ b/src/lib/components/LogViewer.svelte
@@ -19,9 +19,33 @@
 	let autoScroll = $state(true);
 	let logContainer: HTMLElement | null = $state(null);
 	let showContainerDropdown = $state(false);
+	let searchQuery = $state('');
+	let searchRegex = $state<RegExp | null>(null);
+	let searchError = $state<string | null>(null);
+	let searchInput: HTMLInputElement | null = $state(null);
+	let showHelp = $state(false);
+	let lastKey = $state('');
+	let lastKeyTime = $state(0);
+
+	// Update regex when search query changes
+	$effect(() => {
+		if (!searchQuery.trim()) {
+			searchRegex = null;
+			searchError = null;
+			return;
+		}
+		try {
+			searchRegex = new RegExp(searchQuery, 'i');
+			searchError = null;
+		} catch {
+			searchRegex = null;
+			searchError = 'Invalid regex';
+		}
+	});
 
 	const displayLogs = $derived(paused ? pausedLogs : logs);
-	const filteredLogs = $derived(displayLogs.filter((log) => filterLevels.has(log.level)));
+	const levelFilteredLogs = $derived(displayLogs.filter((log) => filterLevels.has(log.level)));
+	const filteredLogs = $derived(searchRegex ? levelFilteredLogs.filter((log) => searchRegex!.test(log.message)) : levelFilteredLogs);
 
 	function togglePause() {
 		if (!paused) {
@@ -95,9 +119,98 @@
 			logContainer.scrollTop = logContainer.scrollHeight;
 		}
 	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		const target = e.target as HTMLElement;
+		const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+		// Always allow Escape to close help
+		if (e.key === 'Escape') {
+			if (showHelp) {
+				showHelp = false;
+				e.preventDefault();
+			}
+			return;
+		}
+
+		// Skip shortcuts when typing in inputs (except Escape)
+		if (isInput) return;
+
+		const now = Date.now();
+		const isSequence = now - lastKeyTime < 500;
+
+		switch (e.key) {
+			case ' ':
+				if (!readonly) {
+					e.preventDefault();
+					togglePause();
+				}
+				break;
+			case '/':
+				e.preventDefault();
+				searchInput?.focus();
+				break;
+			case 'j':
+				if (logContainer) {
+					logContainer.scrollBy({ top: 100, behavior: 'smooth' });
+				}
+				break;
+			case 'k':
+				if (logContainer) {
+					logContainer.scrollBy({ top: -100, behavior: 'smooth' });
+				}
+				break;
+			case 'g':
+				if (isSequence && lastKey === 'g' && logContainer) {
+					logContainer.scrollTo({ top: 0, behavior: 'smooth' });
+					autoScroll = false;
+				}
+				break;
+			case 'G':
+				if (logContainer) {
+					logContainer.scrollTo({ top: logContainer.scrollHeight, behavior: 'smooth' });
+					autoScroll = true;
+				}
+				break;
+			case 's':
+				if (!readonly && paused && onSaveSnapshot) {
+					handleSaveSnapshot();
+				}
+				break;
+			case '?':
+				e.preventDefault();
+				showHelp = !showHelp;
+				break;
+		}
+
+		lastKey = e.key;
+		lastKeyTime = now;
+	}
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
 <div class="log-viewer">
+	{#if showHelp}
+		<div class="help-overlay" onclick={() => (showHelp = false)} onkeydown={(e) => e.key === 'Escape' && (showHelp = false)} role="button" tabindex="-1">
+			<div class="help-modal" onclick={(e) => e.stopPropagation()} onkeydown={() => {}} role="dialog" aria-label="Keyboard shortcuts" tabindex="-1">
+				<h2>Keyboard Shortcuts</h2>
+				<div class="shortcut-list">
+					<div class="shortcut"><kbd>Space</kbd><span>Pause / Resume</span></div>
+					<div class="shortcut"><kbd>/</kbd><span>Focus search</span></div>
+					<div class="shortcut"><kbd>j</kbd><span>Scroll down</span></div>
+					<div class="shortcut"><kbd>k</kbd><span>Scroll up</span></div>
+					<div class="shortcut"><kbd>g g</kbd><span>Go to top</span></div>
+					<div class="shortcut"><kbd>G</kbd><span>Go to bottom</span></div>
+					<div class="shortcut"><kbd>s</kbd><span>Save snapshot (when paused)</span></div>
+					<div class="shortcut"><kbd>?</kbd><span>Toggle this help</span></div>
+					<div class="shortcut"><kbd>Esc</kbd><span>Close help / Clear focus</span></div>
+				</div>
+				<button class="help-close" onclick={() => (showHelp = false)}>Close</button>
+			</div>
+		</div>
+	{/if}
+
 	<div class="controls">
 		{#if !readonly}
 			<div class="control-group">
@@ -147,6 +260,16 @@
 			{/each}
 		</div>
 
+		<div class="search-group">
+			<input type="text" class="search-input" class:error={searchError} placeholder="Search (regex)" bind:value={searchQuery} bind:this={searchInput} />
+			{#if searchQuery}
+				<button class="search-clear" onclick={() => (searchQuery = '')}>x</button>
+			{/if}
+			{#if searchError}
+				<span class="search-error">{searchError}</span>
+			{/if}
+		</div>
+
 		<label class="auto-scroll">
 			<input type="checkbox" bind:checked={autoScroll} />
 			Auto-scroll
@@ -165,7 +288,11 @@
 	</div>
 
 	<div class="status-bar">
-		<span>{filteredLogs.length} logs</span>
+		<span
+			>{filteredLogs.length} logs{#if searchQuery && !searchError}
+				(filtered from {levelFilteredLogs.length}){/if}</span
+		>
+		<span class="help-hint">Press <kbd>?</kbd> for shortcuts</span>
 		{#if paused}
 			<span class="paused-indicator">PAUSED</span>
 		{/if}
@@ -360,6 +487,54 @@
 		font-size: 0.8125rem;
 	}
 
+	.search-group {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		position: relative;
+	}
+
+	.search-input {
+		padding: 0.4rem 0.75rem;
+		border: 1px solid var(--border-color);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		border-radius: 4px;
+		font-size: 0.8125rem;
+		font-family: inherit;
+		width: 160px;
+	}
+
+	.search-input:focus {
+		outline: none;
+		border-color: var(--color-accent);
+	}
+
+	.search-input.error {
+		border-color: var(--color-error);
+	}
+
+	.search-clear {
+		position: absolute;
+		right: 0.5rem;
+		background: none;
+		border: none;
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-size: 0.875rem;
+		padding: 0.25rem;
+		line-height: 1;
+	}
+
+	.search-clear:hover {
+		color: var(--text-primary);
+	}
+
+	.search-error {
+		color: var(--color-error);
+		font-size: 0.75rem;
+	}
+
 	.auto-scroll {
 		display: flex;
 		align-items: center;
@@ -434,5 +609,91 @@
 
 	.version {
 		margin-left: auto;
+	}
+
+	.help-hint {
+		color: var(--text-secondary);
+		font-size: 0.7rem;
+	}
+
+	.help-hint kbd {
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 3px;
+		padding: 0.1rem 0.3rem;
+		font-family: inherit;
+		font-size: 0.65rem;
+	}
+
+	.help-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.help-modal {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		padding: 1.5rem;
+		min-width: 320px;
+		max-width: 90vw;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+	}
+
+	.help-modal h2 {
+		margin: 0 0 1rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.shortcut-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.shortcut {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		font-size: 0.8125rem;
+	}
+
+	.shortcut kbd {
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		padding: 0.25rem 0.5rem;
+		font-family: inherit;
+		font-size: 0.75rem;
+		min-width: 60px;
+		text-align: center;
+		color: var(--color-accent);
+	}
+
+	.shortcut span {
+		color: var(--text-secondary);
+	}
+
+	.help-close {
+		margin-top: 1.5rem;
+		width: 100%;
+		padding: 0.5rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: 0.8125rem;
+	}
+
+	.help-close:hover {
+		background: var(--bg-hover);
 	}
 </style>

--- a/src/lib/components/SnapshotBrowser.svelte
+++ b/src/lib/components/SnapshotBrowser.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snapshot, LogEntry } from '$lib/types';
+	import { exportLogs, type ExportFormat } from '$lib/utils/export';
 
 	interface Props {
 		onViewSnapshot: (logs: LogEntry[], name: string) => void;
@@ -12,6 +13,8 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let deletingId = $state<number | null>(null);
+	let exportingId = $state<number | null>(null);
+	let showExportMenu = $state<number | null>(null);
 
 	async function fetchSnapshots() {
 		loading = true;
@@ -61,6 +64,33 @@
 		}
 	}
 
+	async function handleExport(id: number, format: ExportFormat) {
+		exportingId = id;
+		showExportMenu = null;
+		try {
+			const response = await fetch(`/api/v1/snapshots/${id}`);
+			if (response.ok) {
+				const snapshot: Snapshot = await response.json();
+				if (snapshot.logs) {
+					exportLogs({
+						name: snapshot.name,
+						logs: snapshot.logs,
+						format,
+						createdAt: snapshot.createdAt
+					});
+				}
+			}
+		} catch (err) {
+			console.error('Failed to export snapshot:', err);
+		} finally {
+			exportingId = null;
+		}
+	}
+
+	function toggleExportMenu(id: number) {
+		showExportMenu = showExportMenu === id ? null : id;
+	}
+
 	function formatDate(dateStr: string): string {
 		const date = new Date(dateStr);
 		return date.toLocaleString();
@@ -94,8 +124,20 @@
 						</div>
 						<div class="snapshot-actions">
 							<button class="view-btn" onclick={() => viewSnapshot(snapshot.id)}>View</button>
+							<div class="export-dropdown">
+								<button class="export-btn" onclick={() => toggleExportMenu(snapshot.id)} disabled={exportingId === snapshot.id}>
+									{exportingId === snapshot.id ? '...' : 'Export'}
+								</button>
+								{#if showExportMenu === snapshot.id}
+									<div class="export-menu">
+										<button onclick={() => handleExport(snapshot.id, 'markdown')}>Markdown (LLM)</button>
+										<button onclick={() => handleExport(snapshot.id, 'json')}>JSON</button>
+										<button onclick={() => handleExport(snapshot.id, 'text')}>Plain Text</button>
+									</div>
+								{/if}
+							</div>
 							<button class="delete-btn" onclick={() => deleteSnapshot(snapshot.id)} disabled={deletingId === snapshot.id}>
-								{deletingId === snapshot.id ? '...' : 'Delete'}
+								{deletingId === snapshot.id ? '...' : 'Del'}
 							</button>
 						</div>
 					</div>
@@ -243,5 +285,65 @@
 	.delete-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.export-dropdown {
+		position: relative;
+	}
+
+	.export-btn {
+		padding: 0.35rem 0.75rem;
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 0.75rem;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+	}
+
+	.export-btn:hover {
+		background: var(--bg-hover);
+	}
+
+	.export-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.export-menu {
+		position: absolute;
+		top: 100%;
+		right: 0;
+		margin-top: 0.25rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+		z-index: 10;
+		min-width: 140px;
+	}
+
+	.export-menu button {
+		display: block;
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		background: none;
+		color: var(--text-primary);
+		font-size: 0.75rem;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.export-menu button:hover {
+		background: var(--bg-hover);
+	}
+
+	.export-menu button:first-child {
+		border-radius: 4px 4px 0 0;
+	}
+
+	.export-menu button:last-child {
+		border-radius: 0 0 4px 4px;
 	}
 </style>

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -1,0 +1,141 @@
+import type { LogEntry } from '$lib/types';
+
+export type ExportFormat = 'markdown' | 'json' | 'text';
+
+interface ExportOptions {
+	name: string;
+	logs: LogEntry[];
+	format: ExportFormat;
+	createdAt?: string;
+}
+
+/**
+ * Format logs as Markdown - optimized for LLM context
+ */
+function toMarkdown(name: string, logs: LogEntry[], createdAt?: string): string {
+	const lines: string[] = [];
+
+	lines.push(`# Log Snapshot: ${name}`);
+	lines.push('');
+	if (createdAt) {
+		lines.push(`**Created:** ${new Date(createdAt).toLocaleString()}`);
+	}
+	lines.push(`**Total Entries:** ${logs.length}`);
+	lines.push('');
+
+	// Group by container for better context
+	const byContainer = new Map<string, LogEntry[]>();
+	for (const log of logs) {
+		const existing = byContainer.get(log.container) || [];
+		existing.push(log);
+		byContainer.set(log.container, existing);
+	}
+
+	lines.push('## Summary');
+	lines.push('');
+	lines.push('| Container | Entries | Errors | Warnings |');
+	lines.push('|-----------|---------|--------|----------|');
+	for (const [container, entries] of byContainer) {
+		const errors = entries.filter((e) => e.level === 'error' || e.level === 'alert').length;
+		const warnings = entries.filter((e) => e.level === 'warning').length;
+		lines.push(`| ${container} | ${entries.length} | ${errors} | ${warnings} |`);
+	}
+	lines.push('');
+
+	lines.push('## Logs');
+	lines.push('');
+	lines.push('```');
+	for (const log of logs) {
+		const time = new Date(log.timestamp).toISOString();
+		const level = log.level.toUpperCase().padEnd(7);
+		lines.push(`[${time}] [${level}] [${log.container}] ${log.message}`);
+	}
+	lines.push('```');
+
+	return lines.join('\n');
+}
+
+/**
+ * Format logs as JSON
+ */
+function toJSON(name: string, logs: LogEntry[], createdAt?: string): string {
+	return JSON.stringify(
+		{
+			name,
+			createdAt,
+			exportedAt: new Date().toISOString(),
+			count: logs.length,
+			logs: logs.map((log) => ({
+				timestamp: log.timestamp,
+				container: log.container,
+				level: log.level,
+				stream: log.stream,
+				message: log.message
+			}))
+		},
+		null,
+		2
+	);
+}
+
+/**
+ * Format logs as plain text
+ */
+function toText(name: string, logs: LogEntry[], createdAt?: string): string {
+	const lines: string[] = [];
+
+	lines.push(`Log Snapshot: ${name}`);
+	if (createdAt) {
+		lines.push(`Created: ${new Date(createdAt).toLocaleString()}`);
+	}
+	lines.push(`Total Entries: ${logs.length}`);
+	lines.push('');
+	lines.push('='.repeat(80));
+	lines.push('');
+
+	for (const log of logs) {
+		const time = new Date(log.timestamp).toISOString();
+		const level = log.level.toUpperCase().padEnd(7);
+		lines.push(`[${time}] [${level}] [${log.container}] ${log.message}`);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Export logs to specified format and trigger download
+ */
+export function exportLogs({ name, logs, format, createdAt }: ExportOptions): void {
+	let content: string;
+	let mimeType: string;
+	let extension: string;
+
+	switch (format) {
+		case 'markdown':
+			content = toMarkdown(name, logs, createdAt);
+			mimeType = 'text/markdown';
+			extension = 'md';
+			break;
+		case 'json':
+			content = toJSON(name, logs, createdAt);
+			mimeType = 'application/json';
+			extension = 'json';
+			break;
+		case 'text':
+			content = toText(name, logs, createdAt);
+			mimeType = 'text/plain';
+			extension = 'txt';
+			break;
+	}
+
+	// Create blob and trigger download
+	const blob = new Blob([content], { type: mimeType });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = `${name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${Date.now()}.${extension}`;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import SnapshotBrowser from '$lib/components/SnapshotBrowser.svelte';
 	import type { LogEntry, ContainerSummary } from '$lib/types';
 	import { env } from '$env/dynamic/public';
+	import { exportLogs } from '$lib/utils/export';
 
 	const bufferSize = parseInt(env.PUBLIC_LOG_BUFFER_SIZE || '100', 10);
 
@@ -159,6 +160,15 @@
 		viewingSnapshot = null;
 	}
 
+	function exportCurrentSnapshot() {
+		if (!viewingSnapshot) return;
+		exportLogs({
+			name: viewingSnapshot.name,
+			logs: viewingSnapshot.logs,
+			format: 'markdown'
+		});
+	}
+
 	onMount(async () => {
 		await fetchContainers();
 		connect();
@@ -179,6 +189,7 @@
 		<div class="header-actions">
 			{#if viewingSnapshot}
 				<span class="viewing-snapshot">Viewing: {viewingSnapshot.name}</span>
+				<button class="header-btn export" onclick={exportCurrentSnapshot}>Export MD</button>
 				<button class="header-btn" onclick={closeSnapshotViewer}>Back to Live</button>
 			{:else}
 				<button class="header-btn" class:active={showSnapshotBrowser} onclick={() => (showSnapshotBrowser = !showSnapshotBrowser)}> Snapshots </button>
@@ -297,6 +308,16 @@
 		background: var(--color-accent);
 		color: white;
 		border-color: var(--color-accent);
+	}
+
+	.header-btn.export {
+		background: var(--color-success);
+		color: white;
+		border-color: var(--color-success);
+	}
+
+	.header-btn.export:hover {
+		opacity: 0.9;
 	}
 
 	.viewing-snapshot {


### PR DESCRIPTION
## Summary

- Add regex-based log search with real-time filtering
- Add snapshot export to Markdown, JSON, and plain text formats
- Add keyboard shortcuts for power users

## Search (closes #6)

- Search input in the controls bar with regex support
- Real-time filtering as you type
- Invalid regex error indicator
- Match count displayed in status bar (e.g., "42 logs (filtered from 150)")

## Export (closes #7)

- Export dropdown in snapshot browser with 3 formats
- **Markdown**: LLM-optimized with summary table (error/warning counts)
- **JSON**: Structured data for programmatic use
- **Plain text**: Simple format for logs

Quick "Export MD" button also available when viewing a snapshot on the main page.

## Keyboard Shortcuts (closes #31)

| Key | Action |
|-----|--------|
| `Space` | Pause / Resume |
| `/` | Focus search |
| `j` / `k` | Scroll down / up |
| `g g` | Go to top |
| `G` | Go to bottom |
| `s` | Save snapshot (when paused) |
| `?` | Show shortcuts help |
| `Esc` | Close help / Clear focus |

Press `?` at any time to see the help modal.