### PR TITLE
feat: add log details panel and container events

### DIFF
--- a/src/lib/components/LogViewer.svelte
+++ b/src/lib/components/LogViewer.svelte
@@ -26,6 +26,8 @@
 	let showHelp = $state(false);
 	let lastKey = $state('');
 	let lastKeyTime = $state(0);
+	let selectedLog = $state<LogEntry | null>(null);
+	let copyFeedback = $state(false);
 
 	// Update regex when search query changes
 	$effect(() => {
@@ -114,6 +116,54 @@
 		}
 	}
 
+	function tryParseJson(str: string): { isJson: boolean; parsed: unknown; formatted: string } {
+		try {
+			const parsed = JSON.parse(str);
+			return { isJson: true, parsed, formatted: JSON.stringify(parsed, null, 2) };
+		} catch {
+			return { isJson: false, parsed: null, formatted: str };
+		}
+	}
+
+	function selectLog(log: LogEntry) {
+		selectedLog = selectedLog === log ? null : log;
+	}
+
+	async function copyToClipboard(text: string) {
+		await navigator.clipboard.writeText(text);
+		copyFeedback = true;
+		setTimeout(() => (copyFeedback = false), 1500);
+	}
+
+	function filterByContainer(containerId: string) {
+		// Deselect all, then select only this container
+		selectedContainers.clear();
+		selectedContainers.add(containerId);
+		onContainerFilterChange?.();
+		selectedLog = null;
+	}
+
+	function getEventIcon(eventType: string | undefined): string {
+		switch (eventType) {
+			case 'start':
+				return '▶';
+			case 'stop':
+				return '◼';
+			case 'restart':
+				return '↻';
+			case 'die':
+				return '✕';
+			case 'health_status':
+				return '♥';
+			case 'create':
+				return '+';
+			case 'destroy':
+				return '−';
+			default:
+				return '●';
+		}
+	}
+
 	$effect(() => {
 		if (autoScroll && logContainer && !paused) {
 			logContainer.scrollTop = logContainer.scrollHeight;
@@ -124,10 +174,13 @@
 		const target = e.target as HTMLElement;
 		const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 
-		// Always allow Escape to close help
+		// Always allow Escape to close panels
 		if (e.key === 'Escape') {
 			if (showHelp) {
 				showHelp = false;
+				e.preventDefault();
+			} else if (selectedLog) {
+				selectedLog = null;
 				e.preventDefault();
 			}
 			return;
@@ -276,15 +329,69 @@
 		</label>
 	</div>
 
-	<div class="log-container" bind:this={logContainer}>
-		{#each filteredLogs as log (log.timestamp.toString() + log.message)}
-			<div class="log-entry" style="--level-color: {getLevelColor(log.level)}">
-				<span class="timestamp">{new Date(log.timestamp).toLocaleTimeString()}</span>
-				<span class="container">{log.container}</span>
-				<span class="level">{log.level}</span>
-				<span class="message">{log.message}</span>
+	<div class="log-area">
+		<div class="log-container" bind:this={logContainer}>
+			{#each filteredLogs as log (log.timestamp.toString() + log.message + log.containerId)}
+				<button class="log-entry" class:event={log.isEvent} class:selected={selectedLog === log} style="--level-color: {getLevelColor(log.level)}" onclick={() => selectLog(log)}>
+					<span class="timestamp">{new Date(log.timestamp).toLocaleTimeString()}</span>
+					<span class="container">{log.container}</span>
+					{#if log.isEvent}
+						<span class="event-badge">{getEventIcon(log.eventType)} {log.eventType}</span>
+					{:else}
+						<span class="level">{log.level}</span>
+					{/if}
+					<span class="message">{log.message}</span>
+				</button>
+			{/each}
+		</div>
+
+		{#if selectedLog}
+			{@const jsonResult = tryParseJson(selectedLog.message)}
+			<div class="details-panel">
+				<div class="details-header">
+					<h3>Log Details</h3>
+					<button class="details-close" onclick={() => (selectedLog = null)}>x</button>
+				</div>
+				<div class="details-content">
+					<div class="details-meta">
+						<div class="meta-row">
+							<span class="meta-label">Time</span>
+							<span class="meta-value">{new Date(selectedLog.timestamp).toLocaleString()}</span>
+						</div>
+						<div class="meta-row">
+							<span class="meta-label">Container</span>
+							<span class="meta-value container-value">{selectedLog.container}</span>
+						</div>
+						<div class="meta-row">
+							<span class="meta-label">Level</span>
+							<span class="meta-value level-value" style="--level-color: {getLevelColor(selectedLog.level)}">{selectedLog.level}</span>
+						</div>
+						<div class="meta-row">
+							<span class="meta-label">Stream</span>
+							<span class="meta-value">{selectedLog.stream}</span>
+						</div>
+						{#if selectedLog.isEvent}
+							<div class="meta-row">
+								<span class="meta-label">Event</span>
+								<span class="meta-value">{selectedLog.eventType}</span>
+							</div>
+						{/if}
+					</div>
+					<div class="details-message">
+						<div class="message-header">
+							<span>{jsonResult.isJson ? 'JSON' : 'Message'}</span>
+							<button class="copy-btn" class:copied={copyFeedback} onclick={() => copyToClipboard(jsonResult.isJson ? jsonResult.formatted : selectedLog!.message)}>
+								{copyFeedback ? 'Copied!' : 'Copy'}
+							</button>
+						</div>
+						<pre class="message-content" class:json={jsonResult.isJson}>{jsonResult.isJson ? jsonResult.formatted : selectedLog.message}</pre>
+					</div>
+					<div class="details-actions">
+						<button class="action-btn" onclick={() => filterByContainer(selectedLog!.containerId)}>Filter by this container</button>
+					</div>
+				</div>
 			</div>
-		{/each}
+		{/if}
 	</div>
 
 	<div class="status-bar">
@@ -544,6 +651,12 @@
 		cursor: pointer;
 	}
 
+	.log-area {
+		flex: 1;
+		display: flex;
+		overflow: hidden;
+	}
+
 	.log-container {
 		flex: 1;
 		overflow-y: auto;
@@ -555,15 +668,42 @@
 		grid-template-columns: auto auto auto 1fr;
 		gap: 1rem;
 		padding: 0.25rem 0.5rem;
+		border: none;
 		border-left: 3px solid var(--level-color);
 		margin-bottom: 2px;
 		background: var(--bg-secondary);
 		font-size: 0.8125rem;
 		line-height: 1.4;
+		width: 100%;
+		text-align: left;
+		cursor: pointer;
+		font-family: inherit;
+		color: inherit;
 	}
 
 	.log-entry:hover {
 		background: var(--bg-hover);
+	}
+
+	.log-entry.selected {
+		background: var(--bg-hover);
+		outline: 1px solid var(--color-accent);
+	}
+
+	.log-entry.event {
+		background: linear-gradient(90deg, var(--bg-secondary) 0%, rgba(var(--color-accent-rgb, 99, 102, 241), 0.1) 100%);
+		border-left-color: var(--color-accent);
+	}
+
+	.event-badge {
+		color: var(--color-accent);
+		text-transform: uppercase;
+		font-weight: 600;
+		font-size: 0.75rem;
+		min-width: 80px;
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
 	}
 
 	.timestamp {
@@ -590,6 +730,162 @@
 	.message {
 		color: var(--text-primary);
 		word-break: break-word;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* Details Panel */
+	.details-panel {
+		width: 400px;
+		min-width: 300px;
+		max-width: 50%;
+		background: var(--bg-secondary);
+		border-left: 1px solid var(--border-color);
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.details-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.75rem 1rem;
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.details-header h3 {
+		margin: 0;
+		font-size: 0.875rem;
+		font-weight: 600;
+	}
+
+	.details-close {
+		background: none;
+		border: none;
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-size: 1.25rem;
+		padding: 0.25rem;
+		line-height: 1;
+	}
+
+	.details-close:hover {
+		color: var(--text-primary);
+	}
+
+	.details-content {
+		flex: 1;
+		overflow-y: auto;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.details-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.meta-row {
+		display: flex;
+		gap: 1rem;
+		font-size: 0.8125rem;
+	}
+
+	.meta-label {
+		color: var(--text-secondary);
+		min-width: 80px;
+	}
+
+	.meta-value {
+		color: var(--text-primary);
+	}
+
+	.meta-value.container-value {
+		color: var(--color-accent);
+	}
+
+	.meta-value.level-value {
+		color: var(--level-color);
+		text-transform: uppercase;
+		font-weight: 600;
+	}
+
+	.details-message {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+
+	.message-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.5rem;
+		font-size: 0.75rem;
+		color: var(--text-secondary);
+	}
+
+	.copy-btn {
+		padding: 0.25rem 0.5rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-size: 0.7rem;
+	}
+
+	.copy-btn:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	.copy-btn.copied {
+		color: var(--color-success);
+		border-color: var(--color-success);
+	}
+
+	.message-content {
+		flex: 1;
+		margin: 0;
+		padding: 0.75rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		font-size: 0.75rem;
+		overflow: auto;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.message-content.json {
+		color: var(--color-accent);
+	}
+
+	.details-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.action-btn {
+		flex: 1;
+		padding: 0.5rem;
+		background: var(--bg-primary);
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: 0.8125rem;
+	}
+
+	.action-btn:hover {
+		background: var(--bg-hover);
 	}
 
 	.status-bar {

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -18,9 +18,12 @@ export interface LogEntry {
 	stream: 'stdout' | 'stderr';
 	message: string;
 	level: LogLevel;
+	isEvent?: boolean;
+	eventType?: ContainerEventType;
 }
 
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'alert';
+export type ContainerEventType = 'start' | 'stop' | 'restart' | 'die' | 'health_status' | 'create' | 'destroy';
 
 const LOG_LEVEL_PATTERNS: Record<LogLevel, RegExp[]> = {
 	alert: [/\balert\b/i, /\bcritical\b/i, /\bfatal\b/i, /\bemergency\b/i],
@@ -154,7 +157,7 @@ export async function* streamAllLogs(signal?: AbortSignal, containerIds?: string
 		} else {
 			await new Promise<void>((resolve) => {
 				resolveWait = resolve;
-				setTimeout(resolve, 1000);
+				setTimeout(resolve, 50); // Fast poll for responsive streaming
 			});
 		}
 	}
@@ -162,6 +165,102 @@ export async function* streamAllLogs(signal?: AbortSignal, containerIds?: string
 	for (const { stream } of streams) {
 		(stream as NodeJS.ReadableStream & { destroy?: () => void }).destroy?.();
 	}
+}
+
+const CONTAINER_EVENT_TYPES = new Set(['start', 'stop', 'restart', 'die', 'health_status', 'create', 'destroy']);
+
+function formatEventMessage(action: string, containerName: string, attributes: Record<string, string>): string {
+	switch (action) {
+		case 'start':
+			return `Container started`;
+		case 'stop':
+			return `Container stopped`;
+		case 'restart':
+			return `Container restarted`;
+		case 'die':
+			return `Container exited with code ${attributes.exitCode || 'unknown'}`;
+		case 'health_status':
+			return `Health status: ${attributes.health_status || 'unknown'}`;
+		case 'create':
+			return `Container created`;
+		case 'destroy':
+			return `Container destroyed`;
+		default:
+			return `Container event: ${action}`;
+	}
+}
+
+function getEventLevel(action: string, attributes: Record<string, string>): LogLevel {
+	switch (action) {
+		case 'die':
+			return attributes.exitCode === '0' ? 'info' : 'error';
+		case 'health_status':
+			return attributes.health_status === 'healthy' ? 'info' : 'warning';
+		case 'stop':
+		case 'destroy':
+			return 'warning';
+		case 'start':
+		case 'restart':
+		case 'create':
+			return 'info';
+		default:
+			return 'info';
+	}
+}
+
+export async function* streamContainerEvents(signal?: AbortSignal): AsyncGenerator<LogEntry> {
+	const eventStream = await docker.getEvents({
+		filters: {
+			type: ['container'],
+			event: Array.from(CONTAINER_EVENT_TYPES)
+		}
+	});
+
+	const eventQueue: LogEntry[] = [];
+	let resolveWait: (() => void) | null = null;
+
+	eventStream.on('data', (chunk: Buffer) => {
+		try {
+			const event = JSON.parse(chunk.toString());
+			if (event.Type === 'container' && CONTAINER_EVENT_TYPES.has(event.Action)) {
+				const containerName = event.Actor?.Attributes?.name || event.Actor?.ID?.slice(0, 12) || 'unknown';
+				const entry: LogEntry = {
+					timestamp: new Date(event.time * 1000),
+					container: containerName,
+					containerId: event.Actor?.ID || '',
+					stream: 'stdout',
+					message: formatEventMessage(event.Action, containerName, event.Actor?.Attributes || {}),
+					level: getEventLevel(event.Action, event.Actor?.Attributes || {}),
+					isEvent: true,
+					eventType: event.Action as ContainerEventType
+				};
+				eventQueue.push(entry);
+				if (resolveWait) {
+					resolveWait();
+					resolveWait = null;
+				}
+			}
+		} catch (err) {
+			console.error('Failed to parse Docker event:', err);
+		}
+	});
+
+	eventStream.on('error', (err) => {
+		console.error('Docker events stream error:', err);
+	});
+
+	while (!signal?.aborted) {
+		if (eventQueue.length > 0) {
+			yield eventQueue.shift()!;
+		} else {
+			await new Promise<void>((resolve) => {
+				resolveWait = resolve;
+				setTimeout(resolve, 50); // Fast poll for responsive streaming
+			});
+		}
+	}
+
+	(eventStream as NodeJS.ReadableStream & { destroy?: () => void }).destroy?.();
 }
 
 export async function ping(): Promise<boolean> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,7 @@
 export type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'alert';
 
+export type ContainerEventType = 'start' | 'stop' | 'restart' | 'die' | 'health_status' | 'create' | 'destroy';
+
 export interface LogEntry {
 	timestamp: Date;
 	container: string;
@@ -7,6 +9,8 @@ export interface LogEntry {
 	stream: 'stdout' | 'stderr';
 	message: string;
 	level: LogLevel;
+	isEvent?: boolean;
+	eventType?: ContainerEventType;
 }
 
 export interface ContainerSummary {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,12 +23,12 @@
 	let showSnapshotBrowser = $state(false);
 	let viewingSnapshot = $state<{ name: string; logs: LogEntry[] } | null>(null);
 
-	// Log batching - debounce updates to reduce re-renders (similar to Dozzle)
+	// Log batching - micro-batch for performance while staying responsive
 	let pendingLogs: LogEntry[] = [];
 	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	let lastFlush = 0;
-	const DEBOUNCE_MS = 250; // debounce interval
-	const MAX_WAIT_MS = 1000; // force flush after this long
+	const DEBOUNCE_MS = 50; // short debounce for snappy feel
+	const MAX_WAIT_MS = 150; // force flush quickly for real-time feel
 
 	function flushLogs() {
 		if (pendingLogs.length === 0) return;

--- a/src/routes/api/v1/logs/+server.ts
+++ b/src/routes/api/v1/logs/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types';
-import { streamAllLogs, type LogEntry, type LogLevel } from '$lib/server/docker';
+import { streamAllLogs, streamContainerEvents, type LogEntry, type LogLevel } from '$lib/server/docker';
 import { logsReceived, logsFiltered, activeConnections, bufferSize } from '$lib/server/metrics';
 
 let currentBufferSize = 0;
@@ -8,6 +8,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	const url = new URL(request.url);
 	const levelsParam = url.searchParams.get('levels');
 	const containersParam = url.searchParams.get('containers');
+	const includeEvents = url.searchParams.get('events') !== 'false';
 	const allowedLevels: LogLevel[] | null = levelsParam ? (levelsParam.split(',') as LogLevel[]) : null;
 	const containerIds: string[] | undefined = containersParam ? containersParam.split(',') : undefined;
 
@@ -18,6 +19,16 @@ export const GET: RequestHandler = async ({ request }) => {
 			activeConnections.inc();
 
 			const encoder = new TextEncoder();
+			const entryQueue: LogEntry[] = [];
+			let resolveWait: (() => void) | null = null;
+
+			const queueEntry = (entry: LogEntry) => {
+				entryQueue.push(entry);
+				if (resolveWait) {
+					resolveWait();
+					resolveWait = null;
+				}
+			};
 
 			const send = (data: LogEntry) => {
 				const json = JSON.stringify(data);
@@ -26,23 +37,60 @@ export const GET: RequestHandler = async ({ request }) => {
 				bufferSize.set(currentBufferSize);
 			};
 
-			try {
-				for await (const entry of streamAllLogs(abortController.signal, containerIds)) {
-					logsReceived.inc({ container: entry.container, level: entry.level });
-
-					if (allowedLevels && !allowedLevels.includes(entry.level)) {
-						logsFiltered.inc({ level: entry.level });
-						continue;
+			// Start log stream in background
+			const logStreamPromise = (async () => {
+				try {
+					for await (const entry of streamAllLogs(abortController.signal, containerIds)) {
+						queueEntry(entry);
 					}
-
-					send(entry);
+				} catch (err) {
+					if ((err as Error).name !== 'AbortError') {
+						console.error('Log stream error:', err);
+					}
 				}
-			} catch (err) {
-				if ((err as Error).name !== 'AbortError') {
-					console.error('Log stream error:', err);
+			})();
+
+			// Start events stream in background (if enabled)
+			const eventStreamPromise = includeEvents
+				? (async () => {
+						try {
+							for await (const entry of streamContainerEvents(abortController.signal)) {
+								// Filter events by container if specified
+								if (!containerIds || containerIds.length === 0 || containerIds.includes(entry.containerId) || containerIds.includes(entry.container)) {
+									queueEntry(entry);
+								}
+							}
+						} catch (err) {
+							if ((err as Error).name !== 'AbortError') {
+								console.error('Events stream error:', err);
+							}
+						}
+					})()
+				: Promise.resolve();
+
+			try {
+				while (!abortController.signal.aborted) {
+					if (entryQueue.length > 0) {
+						const entry = entryQueue.shift()!;
+						logsReceived.inc({ container: entry.container, level: entry.level });
+
+						// Events always pass through, logs respect level filter
+						if (!entry.isEvent && allowedLevels && !allowedLevels.includes(entry.level)) {
+							logsFiltered.inc({ level: entry.level });
+							continue;
+						}
+
+						send(entry);
+					} else {
+						await new Promise<void>((resolve) => {
+							resolveWait = resolve;
+							setTimeout(resolve, 25); // Fast poll for real-time feel
+						});
+					}
 				}
 			} finally {
 				activeConnections.dec();
+				await Promise.allSettled([logStreamPromise, eventStreamPromise]);
 				controller.close();
 			}
 		},


### PR DESCRIPTION
## Summary

- Add clickable log entries with expandable details panel
- Stream container lifecycle events into the log view
- Fix sluggish/laggy UI with faster streaming

## Log Details Panel (closes #35)

Click any log entry to open a details panel showing:
- Full timestamp, container, level, stream info
- **JSON pretty-printing** with syntax highlighting for structured logs
- **Copy to clipboard** button
- **Filter by container** button to quickly isolate logs
- Press `Esc` to close the panel

## Container Events (closes #33)

Container lifecycle events are now injected into the log stream:
- `start` - Container started
- `stop` - Container stopped  
- `restart` - Container restarted
- `die` - Container exited (shows exit code)
- `health_status` - Health check changed
- `create` / `destroy` - Container created/destroyed

Events have distinct styling:
- Gradient background with accent color
- Icon badge indicating event type
- Events always pass through level filters (never filtered out)

## Performance Fix

UI was feeling laggy/slow due to aggressive batching:

| Setting | Before | After |
|---------|--------|-------|
| Frontend debounce | 250ms | 50ms |
| Frontend max wait | 1000ms | 150ms |
| Backend poll | 100ms | 25ms |
| Docker stream poll | 1000ms | 50ms |

Now logs appear in near real-time while still batching for efficiency.