### PR TITLE
fix: handle NULL description in snapshot queries

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -146,7 +146,7 @@ func (s *Storage) GetSnapshot(id int64) (*Snapshot, error) {
 	var containersJSON, levelsJSON, logsJSON string
 
 	err := s.db.QueryRow(
-		`SELECT id, name, description, created_at, log_count, containers, levels, logs FROM snapshots WHERE id = ?`,
+		`SELECT id, name, COALESCE(description, ''), created_at, log_count, containers, levels, logs FROM snapshots WHERE id = ?`,
 		id,
 	).Scan(&snap.ID, &snap.Name, &snap.Description, &snap.CreatedAt, &snap.LogCount, &containersJSON, &levelsJSON, &logsJSON)
 	if err == sql.ErrNoRows {
@@ -172,7 +172,7 @@ func (s *Storage) GetSnapshot(id int64) (*Snapshot, error) {
 // ListSnapshots returns all snapshots (without logs for efficiency)
 func (s *Storage) ListSnapshots() ([]Snapshot, error) {
 	rows, err := s.db.Query(
-		`SELECT id, name, description, created_at, log_count, containers, levels FROM snapshots ORDER BY created_at DESC`,
+		`SELECT id, name, COALESCE(description, ''), created_at, log_count, containers, levels FROM snapshots ORDER BY created_at DESC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list snapshots: %w", err)


### PR DESCRIPTION
## Summary

- Use `COALESCE(description, '')` in SQL queries to handle NULL values
- Fixes 500 error when saving/listing snapshots on databases created before v0.9.0

## Root Cause

The `description` column was added in v0.9.0. Old rows have NULL values, which caused scan errors when reading into a Go string.