### PR TITLE
feat: add Claude Code hooks for Jujutsu (jj) support

### DIFF
--- a/.claude/hooks/bash-safety.sh
+++ b/.claude/hooks/bash-safety.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Claude Code Hook: Bash Safety
+# Blocks or warns about dangerous bash commands
+
+set -euo pipefail
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Skip empty commands
+if [[ -z "$command" ]]; then
+    exit 0
+fi
+
+# Dangerous patterns that should be blocked
+# Pattern: rm -rf with root or home paths
+if echo "$command" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|f[a-zA-Z]*r[a-zA-Z]*)\s+(/|~|\$HOME|/home|/usr|/etc|/var|/opt|\.\.)'; then
+    cat >&2 << EOF
+{
+  "decision": "deny",
+  "reason": "Dangerous rm -rf command targeting sensitive directory detected. This could delete critical system or user files.\n\nPlease:\n- Verify the exact path you want to delete\n- Use a more specific path\n- Consider moving to trash instead"
+}
+EOF
+    exit 2
+fi
+
+# Block sudo rm -rf
+if echo "$command" | grep -qE 'sudo\s+rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|f[a-zA-Z]*r[a-zA-Z]*)'; then
+    cat >&2 << EOF
+{
+  "decision": "deny",
+  "reason": "sudo rm -rf is extremely dangerous and blocked by policy.\n\nIf you need to remove system files, please do so manually with careful verification."
+}
+EOF
+    exit 2
+fi
+
+# Warn about chmod 777
+if echo "$command" | grep -qE 'chmod\s+777'; then
+    cat >&2 << EOF
+{
+  "decision": "deny",
+  "reason": "chmod 777 grants full permissions to everyone - this is a security risk.\n\nConsider:\n- chmod 755 for directories\n- chmod 644 for files\n- chmod 700 for private directories"
+}
+EOF
+    exit 2
+fi
+
+# Warn about curl | bash patterns
+if echo "$command" | grep -qE 'curl.*\|\s*(sudo\s+)?bash|wget.*\|\s*(sudo\s+)?bash'; then
+    cat >&2 << EOF
+{
+  "decision": "ask",
+  "reason": "Piping curl/wget directly to bash can execute arbitrary code.\n\nConsider:\n1. Download the script first\n2. Review its contents\n3. Then execute if safe"
+}
+EOF
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/code-quality.sh
+++ b/.claude/hooks/code-quality.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Claude Code Hook: Code Quality Warnings
+# Warns about debug statements and other code quality issues after file writes
+
+set -euo pipefail
+
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // ""')
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.filePath // ""')
+
+# Only check Write and Edit operations
+if [[ "$tool_name" != "Write" && "$tool_name" != "Edit" ]]; then
+    exit 0
+fi
+
+# Skip if no file path
+if [[ -z "$file_path" || "$file_path" == "null" ]]; then
+    exit 0
+fi
+
+# Skip non-code files
+case "$file_path" in
+    *.md|*.txt|*.json|*.yaml|*.yml|*.toml|*.lock|*.sum)
+        exit 0
+        ;;
+esac
+
+# Check if file exists
+if [[ ! -f "$file_path" ]]; then
+    exit 0
+fi
+
+warnings=()
+
+# Check for debug statements based on file type
+case "$file_path" in
+    *.go)
+        if grep -qE '^\s*fmt\.Print|^\s*log\.Print|^\s*println\(' "$file_path" 2>/dev/null; then
+            warnings+=("Go debug statements (fmt.Print/log.Print) detected - use structured logging")
+        fi
+        ;;
+    *.js|*.ts|*.jsx|*.tsx)
+        if grep -qE '^\s*console\.(log|debug|info)\(' "$file_path" 2>/dev/null; then
+            warnings+=("console.log statements detected - consider using a proper logger or removing before commit")
+        fi
+        if grep -qE '^\s*debugger\s*;?' "$file_path" 2>/dev/null; then
+            warnings+=("debugger statement detected - remove before commit")
+        fi
+        ;;
+    *.py)
+        if grep -qE '^\s*print\s*\(' "$file_path" 2>/dev/null; then
+            warnings+=("print() statements detected - consider using logging module")
+        fi
+        if grep -qE '^\s*breakpoint\s*\(\)' "$file_path" 2>/dev/null; then
+            warnings+=("breakpoint() detected - remove before commit")
+        fi
+        ;;
+    *.rs)
+        if grep -qE '^\s*println!\s*\(' "$file_path" 2>/dev/null; then
+            warnings+=("println! macro detected - consider using log/tracing crate")
+        fi
+        if grep -qE '^\s*dbg!\s*\(' "$file_path" 2>/dev/null; then
+            warnings+=("dbg! macro detected - remove before commit")
+        fi
+        ;;
+esac
+
+# Check for TODO/FIXME in new code (all file types)
+if grep -qE '(TODO|FIXME|XXX|HACK):?' "$file_path" 2>/dev/null; then
+    warnings+=("TODO/FIXME comments found - consider addressing or creating an issue")
+fi
+
+# Output warnings if any
+if [[ ${#warnings[@]} -gt 0 ]]; then
+    echo ""
+    echo "Code Quality Warnings for $file_path:"
+    for warning in "${warnings[@]}"; do
+        echo "  - $warning"
+    done
+    echo ""
+fi
+
+exit 0

--- a/.claude/hooks/detect-vcs.sh
+++ b/.claude/hooks/detect-vcs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Claude Code Hook: VCS Detection
+# Detects the version control system and sets environment variables
+
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR" || exit 1
+
+# Detect VCS type
+if [ -d ".jj" ]; then
+    echo "Detected Jujutsu (jj) repository"
+    echo "export VCS_TYPE=jj" >> "$CLAUDE_ENV_FILE"
+    
+    # Check if colocated with git
+    if [ -d ".git" ]; then
+        echo "  (colocated with git)"
+        echo "export JJ_COLOCATED=true" >> "$CLAUDE_ENV_FILE"
+    fi
+    
+    # Show current status
+    if command -v jj >/dev/null 2>&1; then
+        echo ""
+        echo "Current jj status:"
+        jj log --limit 3 2>/dev/null || true
+    fi
+elif [ -d ".git" ]; then
+    echo "Detected Git repository"
+    echo "export VCS_TYPE=git" >> "$CLAUDE_ENV_FILE"
+else
+    echo "No version control detected"
+    echo "export VCS_TYPE=none" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/.claude/hooks/jj-validator.sh
+++ b/.claude/hooks/jj-validator.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Claude Code Hook: Jujutsu (jj) Command Validator
+# Intercepts git commands in jj repositories and suggests jj equivalents
+
+set -euo pipefail
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Check if we're in a jj repo
+if [ ! -d ".jj" ]; then
+    exit 0
+fi
+
+# Git command translations
+declare -A JJ_TRANSLATIONS=(
+    ["git status"]="jj status"
+    ["git log"]="jj log"
+    ["git diff"]="jj diff"
+    ["git add"]="jj (auto-tracks, no add needed)"
+    ["git commit"]="jj describe -m 'message' && jj new"
+    ["git commit -m"]="jj describe -m 'message' && jj new"
+    ["git commit --amend"]="jj describe -m 'message'"
+    ["git push"]="jj git push"
+    ["git pull"]="jj git fetch && jj rebase -d main"
+    ["git fetch"]="jj git fetch"
+    ["git checkout"]="jj new <revision>"
+    ["git checkout -b"]="jj new main -m 'branch description'"
+    ["git branch"]="jj branch list"
+    ["git merge"]="jj rebase"
+    ["git rebase"]="jj rebase"
+    ["git stash"]="jj (not needed, working copy is auto-saved)"
+    ["git reset"]="jj restore / jj abandon"
+    ["git revert"]="jj backout"
+    ["git cherry-pick"]="jj duplicate"
+    ["git show"]="jj show"
+    ["git blame"]="jj file annotate"
+)
+
+# Check if command starts with a git command
+for git_cmd in "${!JJ_TRANSLATIONS[@]}"; do
+    if [[ "$command" == "$git_cmd"* ]]; then
+        jj_equiv="${JJ_TRANSLATIONS[$git_cmd]}"
+        cat >&2 << EOF
+{
+  "decision": "deny",
+  "reason": "This is a Jujutsu (jj) repository, not a standard git repo. Use jj commands instead.\n\nGit command: $git_cmd\nJujutsu equivalent: $jj_equiv\n\nKey jj concepts:\n- Working copy changes are automatically tracked (no 'add' needed)\n- 'jj new' creates a new change, 'jj describe' sets the message\n- Use 'jj git push' to push to remote\n- Use 'jj log' to see history"
+}
+EOF
+        exit 2
+    fi
+done
+
+# Check for git commands that are compatible with jj's colocated mode
+# These can pass through but we should warn
+PASSTHROUGH_CMDS=("git remote" "git config" "git clone")
+for git_cmd in "${PASSTHROUGH_CMDS[@]}"; do
+    if [[ "$command" == "$git_cmd"* ]]; then
+        # Allow these to pass through in colocated repos
+        exit 0
+    fi
+done
+
+# Generic git command detection
+if [[ "$command" == git\ * ]]; then
+    cat >&2 << EOF
+{
+  "decision": "deny", 
+  "reason": "This is a Jujutsu (jj) repository. Please use jj commands instead of git.\n\nCommon jj commands:\n- jj status - Show working copy status\n- jj log - Show commit history\n- jj diff - Show changes\n- jj describe -m 'msg' - Set commit message\n- jj new - Create new change\n- jj git push - Push to remote\n\nSee: https://martinvonz.github.io/jj/latest/git-comparison/"
+}
+EOF
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/detect-vcs.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/jj-validator.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/bash-safety.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/code-quality.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ node_modules/
 # VCS
 .jj/
 
-# AI tooling
-.claude/
+# AI tooling (keep local settings private)
+.claude/settings.local.json
 
 # Build outputs
 /.svelte-kit


### PR DESCRIPTION
## Summary

Add Claude Code hooks to enforce proper Jujutsu (jj) usage and improve code quality in this repository.

## Hooks Added

### 1. VCS Detection (`detect-vcs.sh`)
**Event:** SessionStart

Detects if you're in a jj repo and sets environment variables:
- `VCS_TYPE=jj` 
- `JJ_COLOCATED=true` (if colocated with git)

### 2. Jujutsu Validator (`jj-validator.sh`)
**Event:** PreToolUse (Bash)

Intercepts `git` commands and provides jj equivalents:

| Git Command | Jujutsu Equivalent |
|-------------|-------------------|
| `git status` | `jj status` |
| `git log` | `jj log` |
| `git diff` | `jj diff` |
| `git commit -m "msg"` | `jj describe -m "msg" && jj new` |
| `git push` | `jj git push` |
| `git pull` | `jj git fetch && jj rebase -d main` |
| `git checkout -b` | `jj new main -m "description"` |
| `git stash` | (not needed - jj auto-saves) |

### 3. Bash Safety (`bash-safety.sh`)
**Event:** PreToolUse (Bash)

Blocks dangerous commands:
- `rm -rf /` or targeting system directories
- `sudo rm -rf`
- `chmod 777`
- `curl | bash` patterns (asks for confirmation)

### 4. Code Quality Warnings (`code-quality.sh`)
**Event:** PostToolUse (Write|Edit)

Warns about debug statements after file writes:
- **Go:** `fmt.Print`, `log.Print`
- **JS/TS:** `console.log`, `debugger`
- **Python:** `print()`, `breakpoint()`
- **Rust:** `println!`, `dbg!`
- **All:** TODO/FIXME comments

## Files Changed

- `.claude/settings.json` - Hook configuration
- `.claude/hooks/detect-vcs.sh` - VCS detection
- `.claude/hooks/jj-validator.sh` - Git to jj translation
- `.claude/hooks/bash-safety.sh` - Dangerous command blocking
- `.claude/hooks/code-quality.sh` - Debug statement warnings
- `.gitignore` - Allow `.claude/` (keep `.claude/settings.local.json` private)

## Testing

After merging, restart Claude Code in this repo. The hooks will activate automatically.