### PR TITLE
fix: add database migration for log_count column

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -84,6 +84,22 @@ func (s *Storage) migrate() error {
 		}
 	}
 
+	// Add log_count column if it doesn't exist (migration for older databases)
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('snapshots') WHERE name='log_count'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for log_count column: %w", err)
+	}
+	if count == 0 {
+		if _, err := s.db.Exec(`ALTER TABLE snapshots ADD COLUMN log_count INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("failed to add log_count column: %w", err)
+		}
+		// Backfill log_count from existing logs data
+		if _, err := s.db.Exec(`UPDATE snapshots SET log_count = json_array_length(logs) WHERE log_count = 0`); err != nil {
+			// Non-fatal: just log, the count will be 0 for old snapshots
+			fmt.Printf("warning: failed to backfill log_count: %v\n", err)
+		}
+	}
+
 	return nil
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -445,7 +445,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
     try {
       const response = await fetch("/api/v1/snapshots");
-      const snapshots = await response.json();
+      const data = await response.json();
+      
+      // Handle error responses or non-array data
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to fetch snapshots");
+      }
+      
+      const snapshots = Array.isArray(data) ? data : [];
 
       if (snapshots.length === 0) {
         container.innerHTML = `


### PR DESCRIPTION
## Summary

Fixes #63 - Snapshots fail to load with "snapshots.map is not a function" error.

## Root Cause

The `snapshots` table was missing the `log_count` column in older databases. The `CREATE TABLE IF NOT EXISTS` statement doesn't add new columns to existing tables.

## Changes

### Backend (`internal/storage/storage.go`)
- Added migration to add `log_count` column if it doesn't exist
- Backfills `log_count` from existing `logs` JSON data using `json_array_length()`

### Frontend (`static/app.js`)
- Added defensive checks for API error responses
- Ensures `snapshots` is always an array before calling `.map()`

## Testing

1. Start Loggarr with an existing database (created before v0.11.0)
2. Open Snapshots modal
3. Should load without errors
4. Existing snapshots should show correct log counts