### PR TITLE
fix: remove redundant newline in fmt.Println

### DIFF
--- a/cmd/loggarr/main.go
+++ b/cmd/loggarr/main.go
@@ -135,7 +135,7 @@ func main() {
 }
 
 func printBanner(cfg *config.Config) {
-	fmt.Println(`
+	fmt.Print(`
  _                                  
 | |    ___   __ _  __ _  __ _ _ __ _ __ 
 | |   / _ \ / _' |/ _' |/ _' | '__| '__|


### PR DESCRIPTION
## Summary

Fix Go vet error causing CI to fail:

```
cmd/loggarr/main.go:138:2: fmt.Println arg list ends with redundant newline
```

## Change

Changed `fmt.Println` to `fmt.Print` in `printBanner()` since the banner string already ends with a newline.